### PR TITLE
Fix native RL trainers training mode

### DIFF
--- a/mlx_tune/rl_trainers.py
+++ b/mlx_tune/rl_trainers.py
@@ -105,6 +105,16 @@ def _save_adapters_and_config(model, adapter_path: Path):
         return False
 
 
+def _set_native_train_mode(model, actual_model):
+    """Ensure wrapped native RL models run with training-time behavior enabled."""
+    seen = set()
+    for candidate in (model, actual_model):
+        if candidate is None or id(candidate) in seen or not hasattr(candidate, "train"):
+            continue
+        candidate.train()
+        seen.add(id(candidate))
+
+
 class DPOConfig:
     """
     Configuration for Direct Preference Optimization training.
@@ -442,6 +452,7 @@ class DPOTrainer:
 
         # Get actual model
         actual_model = self.model.model if hasattr(self.model, 'model') else self.model
+        _set_native_train_mode(self.model, actual_model)
 
         # Create optimizer
         lr_schedule = optim.cosine_decay(self.learning_rate, self.iters)
@@ -681,6 +692,7 @@ class ORPOTrainer:
         print(f"✓ Prepared {len(tokenized_data)} preference pairs")
 
         actual_model = self.model.model if hasattr(self.model, 'model') else self.model
+        _set_native_train_mode(self.model, actual_model)
         lr_schedule = optim.cosine_decay(self.learning_rate, self.iters)
         optimizer = optim.AdamW(learning_rate=lr_schedule)
 
@@ -995,6 +1007,7 @@ class KTOTrainer:
             self.model._apply_lora()
 
         actual_model = self.model.model if hasattr(self.model, 'model') else self.model
+        _set_native_train_mode(self.model, actual_model)
         lr_schedule = optim.cosine_decay(self.learning_rate, self.iters)
         optimizer = optim.AdamW(learning_rate=lr_schedule)
 
@@ -1127,6 +1140,7 @@ class SimPOTrainer:
         print(f"✓ Prepared {len(tokenized_data)} preference pairs")
 
         actual_model = self.model.model if hasattr(self.model, 'model') else self.model
+        _set_native_train_mode(self.model, actual_model)
         lr_schedule = optim.cosine_decay(self.learning_rate, self.iters)
         optimizer = optim.AdamW(learning_rate=lr_schedule)
 

--- a/tests/test_rl_trainers_integration.py
+++ b/tests/test_rl_trainers_integration.py
@@ -155,6 +155,88 @@ def grpo_dataset():
     ]
 
 
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("trainer_factory", "loss_attr", "dataset_name"),
+    [
+        ("dpo", "compute_dpo_loss", "preference"),
+        ("orpo", "compute_orpo_loss", "preference"),
+        ("kto", "compute_kto_loss", "kto"),
+        ("simpo", "compute_simpo_loss", "preference"),
+    ],
+)
+def test_native_rl_trainers_enable_train_mode(
+    monkeypatch,
+    mock_tokenizer,
+    preference_dataset,
+    kto_dataset,
+    tmp_path,
+    trainer_factory,
+    loss_attr,
+    dataset_name,
+):
+    """Native gradient-based RL trainers should switch models into training mode."""
+    import mlx_tune.rl_trainers as rl_trainers
+    from mlx_tune import DPOTrainer, DPOConfig, ORPOTrainer, ORPOConfig, KTOTrainer, SimPOTrainer
+
+    monkeypatch.setattr(rl_trainers, "HAS_NATIVE_TRAINING", True)
+    monkeypatch.setattr(rl_trainers, "_save_adapters_and_config", lambda *args, **kwargs: True)
+
+    observed = {"training": None}
+
+    def pair_loss(model, chosen_ids, rejected_ids, chosen_lengths, rejected_lengths, *args, **kwargs):
+        observed["training"] = model.training
+        loss = model(chosen_ids).mean() - model(rejected_ids).mean()
+        return loss, mx.array(chosen_lengths.sum() + rejected_lengths.sum())
+
+    def kto_loss(model, input_ids, lengths, labels, *args, **kwargs):
+        observed["training"] = model.training
+        loss = model(input_ids).mean() + labels.mean() * 0.0
+        return loss, mx.array(lengths.sum())
+
+    monkeypatch.setattr(rl_trainers, loss_attr, kto_loss if dataset_name == "kto" else pair_loss)
+
+    model = MockModelWrapper(SmallLanguageModel())
+    mx.eval(model.model.parameters())
+
+    if trainer_factory == "dpo":
+        trainer = DPOTrainer(
+            model=model,
+            train_dataset=preference_dataset,
+            tokenizer=mock_tokenizer,
+            args=DPOConfig(max_steps=1, logging_steps=1, save_steps=10, output_dir=str(tmp_path / "dpo")),
+        )
+    elif trainer_factory == "orpo":
+        trainer = ORPOTrainer(
+            model=model,
+            train_dataset=preference_dataset,
+            tokenizer=mock_tokenizer,
+            args=ORPOConfig(max_steps=1, logging_steps=1, save_steps=10, output_dir=str(tmp_path / "orpo")),
+        )
+    elif trainer_factory == "kto":
+        trainer = KTOTrainer(
+            model=model,
+            train_dataset=kto_dataset,
+            tokenizer=mock_tokenizer,
+            max_steps=1,
+            logging_steps=1,
+            output_dir=str(tmp_path / "kto"),
+        )
+    else:
+        trainer = SimPOTrainer(
+            model=model,
+            train_dataset=preference_dataset,
+            tokenizer=mock_tokenizer,
+            max_steps=1,
+            logging_steps=1,
+            output_dir=str(tmp_path / "simpo"),
+        )
+
+    trainer.train()
+
+    assert observed["training"] is True
+
+
 # =============================================================================
 # DPO TRAINER INTEGRATION TESTS
 # =============================================================================


### PR DESCRIPTION
## Summary

This fixes native preference-optimization training running with models left in inference mode.

The immediate user-facing failure was native DPO crashing on Qwen3.5-style models with:

```text
ValueError: [Primitive::vjp] Not implemented for CustomKernel
```

The root cause was not the DPO loss itself. The problem was that the native RL trainer paths were building gradients without explicitly switching the model to training mode first.

For Qwen3.5-style models, that matters because the linear-attention path changes behavior based on `self.training`. When the model stays in inference mode, it can take an inference-only Metal custom-kernel path. That kernel does not provide the VJP needed for gradient computation, so native training fails.

This PR ensures the native gradient-based RL trainer paths enter training mode before calling `nn.value_and_grad(...)`.

## Root Cause

In `mlx_tune/rl_trainers.py`, native RL training extracted the underlying trainable model and immediately built:

```python
loss_and_grad = nn.value_and_grad(actual_model, loss_fn)
```

but it never called `train()` first.

That means wrapped models could still be in inference mode when the forward pass used for backpropagation ran.

For Qwen3.5-style models, this is especially important because the model code uses `self.training` to decide whether to use the inference-oriented kernel path.

In practice, explicitly calling `train()` before native DPO training avoids the crash and allows a bf16 DPO pilot step to complete.

## What Changed

Added a small helper in `mlx_tune/rl_trainers.py`:

- `_set_native_train_mode(model, actual_model)`

This calls `train()` on both:
- the wrapper object, if it exposes `train()`
- the unwrapped underlying model used for gradient computation

The helper is then called before native optimizer/gradient setup in the RL trainer paths that actually use native gradient-based optimization:

- `DPOTrainer._train_native()`
- `ORPOTrainer._train_native()`
- `KTOTrainer._train_native()`
- `SimPOTrainer._train_native()`

## Why The Fix Covers More Than DPO

Although DPO was the reported failure, the same bug pattern existed in other native RL trainer paths.

`ORPO`, `KTO`, and `SimPO` also:
- unwrap `actual_model`
- construct `nn.value_and_grad(...)`
- perform native gradient updates
- previously did not switch the model into training mode first

Since the issue is structural and identical in those paths, fixing only DPO would leave the same latent bug elsewhere.

I did **not** expand the fix to GRPO because its native path is materially different and does not currently use the same `value_and_grad(...)` training loop.

## What This PR Does Not Change

This PR is intentionally narrow.

It does **not**:
- add any fallback-to-SFT behavior
- change dataset handling or dataset semantics
- change DPO/ORPO/KTO/SimPO loss definitions
- change tokenization, padding, or batching behavior
- alter GRPO behavior

## Tests Added

Added a regression test in `tests/test_rl_trainers_integration.py` that verifies native RL trainer paths enter the loss function with `model.training == True`.

This test covers:
- DPO
- ORPO
- KTO
- SimPO

The test uses patched loss functions to directly observe the training flag seen by the model during native training.

## Validation

Ran the full pytest suite after the fix.

Result:
- `504 passed`
- `1 skipped`
- `12 deselected`

The focused RL regression also passed, and the full RL integration file passed as part of the full suite.

### Manual Smoke Validation

In addition to the automated test coverage, I manually validated the reported failure mode against a real Qwen3.5 bf16 native DPO setup.

Smoke setup:
- model: `mlx-community/Qwen3.5-4B-MLX-bf16`
- trainer: native `DPOTrainer`
- data: 8 preference pairs from a prepared DPO dataset
- config: LoRA adapters, `max_steps=1`

Result:
- native DPO completed successfully
- observed training log included:
  - `Step 1/1 | Loss: 0.6914`
  - `DPO Training Complete!`

This is the same code path that previously failed with:

```text
ValueError: [Primitive::vjp] Not implemented for CustomKernel
```

After the fix, that smoke run no longer reproduces the failure.

## Files Changed

- `mlx_tune/rl_trainers.py`
- `tests/test_rl_trainers_integration.py`

## Rationale

The correct fix is to ensure native training code actually runs in training mode before gradient computation.

That matches expected ML training semantics, matches how native SFT-style training is already handled elsewhere, and avoids inference-only code paths being used during backpropagation.