### PR TITLE
Forward SFT gradient accumulation to MLX-LM

### DIFF
--- a/mlx_tune/sft_trainer.py
+++ b/mlx_tune/sft_trainer.py
@@ -613,6 +613,7 @@ class SFTTrainer:
             max_seq_length=self.max_seq_length,
             adapter_file=adapter_file,
             grad_checkpoint=self._should_use_grad_checkpoint(),
+            grad_accumulation_steps=self.gradient_accumulation_steps,
         )
 
         print(f"\nTraining configuration:")
@@ -621,6 +622,7 @@ class SFTTrainer:
         print(f"  Learning rate: {self.learning_rate}")
         print(f"  LR scheduler: {self.lr_scheduler_type}")
         print(f"  Grad checkpoint: {training_args.grad_checkpoint}")
+        print(f"  Gradient accumulation: {training_args.grad_accumulation_steps}")
         print(f"  Adapter file: {adapter_file}")
         print()
 

--- a/tests/test_trainers.py
+++ b/tests/test_trainers.py
@@ -127,6 +127,43 @@ class TestTrainerInitialization:
         assert KTOTrainer is not None
         assert SimPOTrainer is not None
 
+    def test_sft_native_training_forwards_gradient_accumulation(self, monkeypatch, tmp_path):
+        """Test SFTTrainer forwards gradient accumulation to MLX-LM TrainingArgs."""
+        from mlx_tune import SFTConfig, SFTTrainer
+        import mlx_tune.sft_trainer as sft_trainer
+
+        if not sft_trainer.HAS_NATIVE_TRAINING:
+            pytest.skip("Native MLX-LM training components are not available")
+
+        captured = {}
+
+        def fake_train(**kwargs):
+            captured["args"] = kwargs["args"]
+
+        trainer = SFTTrainer(
+            model=object(),
+            train_dataset=[{"text": "hello"}],
+            args=SFTConfig(
+                output_dir=str(tmp_path / "output"),
+                max_steps=1,
+                per_device_train_batch_size=1,
+                gradient_accumulation_steps=7,
+            ),
+            adapter_path=str(tmp_path / "adapter"),
+        )
+
+        monkeypatch.setattr(trainer, "_prepare_training_data", lambda: str(tmp_path))
+        monkeypatch.setattr(trainer, "_get_lr_schedule", lambda: 1e-4)
+        monkeypatch.setattr(trainer, "_save_adapter_config", lambda: None)
+        monkeypatch.setattr(sft_trainer, "mlx_load_dataset", lambda **kwargs: ([1], [1], None))
+        monkeypatch.setattr(sft_trainer, "CacheDataset", lambda dataset: dataset)
+        monkeypatch.setattr(sft_trainer, "mlx_train", fake_train)
+
+        result = trainer._train_native()
+
+        assert result["status"] == "success"
+        assert captured["args"].grad_accumulation_steps == 7
+
 
 class TestLossFunctionImports:
     """Test loss function imports."""


### PR DESCRIPTION
## Summary

- forward `SFTConfig.gradient_accumulation_steps` into MLX-LM `TrainingArgs`
- print the effective native-training gradient accumulation value in the SFT config log
- add a mock-based regression test that verifies native SFT training passes the configured value through

## Why

`SFTTrainer` already reads and stores `gradient_accumulation_steps`, but the native MLX training path did not pass it into `mlx_lm.tuner.trainer.TrainingArgs`, so MLX-LM used its default of `1`.

This makes the Unsloth-compatible `SFTConfig(gradient_accumulation_steps=...)` behave as expected for native SFT training.

## Tests

```bash
.venv/bin/python -m pytest tests/test_trainers.py -q
# 16 passed

.venv/bin/python -m py_compile mlx_tune/sft_trainer.py tests/test_trainers.py
git diff --check
```

Notes:

- `uv run pytest tests/test_trainers.py -q` currently fails during dependency resolution before tests run because `pyproject.toml` allows Python `>=3.9`, while `mlx>=0.31.0` requires Python `>=3.10`.
- `ruff check mlx_tune/sft_trainer.py tests/test_trainers.py` reports pre-existing style issues in these files, so I did not broaden this bugfix PR into a formatting cleanup.
